### PR TITLE
MK3 Fix temperature dependent 1st layer height

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3759,7 +3759,7 @@ void process_commands()
 				SERIAL_ECHOLNPGM("");
 			}*/
 //			#endif // SUPPORT_VERBOSITY
-			mbl.set_z(ix, iy, current_position[Z_AXIS] - offset_z); //store measured z values z_values[iy][ix] = z - offset_z;
+			mbl.set_z(ix, iy, current_position[Z_AXIS] + offset_z); //store measured z values z_values[iy][ix] = z + offset_z;
 
 			custom_message_state--;
 			mesh_point++;


### PR DESCRIPTION
There is a substraction of the temperature compensation offset in the mesh bed leveling function that must be changed into an addition in order to achieve perfect first layers in a wide range of PINDA temperatures.

Background:
Replacing the PINDA probe and then replacing the complete MK3 did not solve my problem that I was incapabe of achieving a perfect - or sometimes even a working - first layer. With everyprint I had to adjust the live z value. I had to start prints multiple times before the first layer was roughly OK to let the print progress.

Since hardware replacements did not help I started to dig into the firmware to search for a reason or even a solution for the problem.

I started by commenting out that line were the offset_z is set to the PINDA temperature corrected value. Thus the offset was always zero. Instantly the first layer height got far more consistent and much less temperature influenced. Then I knew what I should focus on next.

The problem is that the warmer the PINDA gets, the less negative I have to set the live adjust value. When the printer is cooled down again, the live z value must be set way more negative again.
That is because the PINDA probe triggers lower with increasing temperature.
The problem with the stock firmware is until now, that the PINDA triggers lower and still the firmware SUBTRACTS roughly the same amount of millimeters instead of ADDING that amount in order to compensate the physics of the PINDA probe.

Using this little patch now results in perfect first layers every time for me and I even can fine tune the first layer among multiple prints - that was absolutely impossible for me before.

fixes #373